### PR TITLE
Content-Length & no response fixes

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -92,6 +92,7 @@ function sendToHost(server, messageObj, finished, forward) {
   var headers = messageObj.headers || {};
   if (headers.host) headers.host = url.parse(hostUrl).host;
   headers['content-type'] = headers['content-type'] || 'application/json'; // default to json content-type
+  delete headers['content-length']; // change: body content can contain null values, so force request() to recalculate content-length
   var options = {
     url: hostUrl,
     method: messageObj.method,
@@ -114,7 +115,7 @@ function sendToHost(server, messageObj, finished, forward) {
     };
     q.emit('feder8-response', params);
     if (params.responseObj && params.responseObj.responseSent) return; // if request error, response can be undefined
-    if (response && response.responseSent) return;
+    if (response && response.responseSent) return; // change: response can be undefined
     if (error) {
       finished({error: error});
     }


### PR DESCRIPTION
- ensure correct Content-Length (re)calculation
- the response object can be undefined